### PR TITLE
Cython - Address build warning

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,10 +4,33 @@ from pathlib import Path
 
 import numpy
 from setuptools import Extension, setup
-from Cython.Distutils import build_ext
+from Cython.Build import cythonize
 
-# Allow user to specify a compiler; default to gcc if not provided
-os.environ.setdefault("CC", "gcc")
+# Give user option to specify local compiler name
+if "CC" not in os.environ:
+    os.environ["CC"] = "gcc"
+
+print("Compiler set to: " + os.environ["CC"])
+
+extension_params = dict(
+    extra_compile_args=[
+        '-fopenmp',
+        '-O3',
+    ],
+    extra_link_args=['-fopenmp'],
+    include_dirs=[numpy.get_include()]
+)
+
+directives = {
+    'language_level': "3str",
+    'embedsignature': True,
+    'boundscheck': False,
+    'wraparound': False,
+    'initializedcheck': False,
+    'cdivision': True,
+    'binding': True,
+}
+
 
 source_location = Path("topocalc") / "core_c"
 
@@ -18,14 +41,15 @@ extensions = [
             str(source_location / "topo_core.pyx"),
             str(source_location / "hor1d.c"),
         ],
-        include_dirs=[numpy.get_include()],
-        extra_compile_args=["-fopenmp", "-O3"],
-        extra_link_args=["-fopenmp", "-O3"],
+        **extension_params
     )
 ]
 
 setup(
     name="topocalc",
-    cmdclass={"build_ext": build_ext},
-    ext_modules = extensions
+    ext_modules=cythonize(
+        extensions,
+        compiler_directives=directives,
+        annotate=False,
+    ),
 )

--- a/topocalc/core_c/illumination_angle.pyx
+++ b/topocalc/core_c/illumination_angle.pyx
@@ -1,9 +1,3 @@
-# cython: language_level=3
-# cython: boundscheck=False
-# cython: wraparound=False
-# cython: cdivision=True
-# distutils: language = c
-
 import numpy as np
 cimport numpy as np
 from libc.math cimport cos, sin, sqrt, pi, acos

--- a/topocalc/core_c/topo_core.pyx
+++ b/topocalc/core_c/topo_core.pyx
@@ -1,10 +1,6 @@
 """
 C implementation of some radiation functions
 """
-# cython: language_level=3
-# cython: boundscheck=False
-# cython: wraparound=False
-# cython: cdivision=True
 # distutils: language = c
 # distutils: define_macros=NPY_NO_DEPRECATED_API=NPY_1_7_API_VERSION
 


### PR DESCRIPTION
Fixes the following:
```
Warning: Multiple cython sources found for extension 'topocalc.topo_core':
  ['topocalc/core_c/illumination_angle.pyx', 'topocalc/core_c/topo_core.pyx']
```

The `illumination_angle.pyx` is already imported in `topo_core.pyx`
https://github.com/iSnobal/topocalc/blob/97b726967859059101f2166e203e5ca6fa3a7c39/topocalc/core_c/topo_core.pyx#L15

Also updates the `setup.py` to latest Cython practices.