### PR TITLE
Revert to original skew method and filter out striping artifacts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,7 @@
 requires = [
   "Cython",
   "numpy<1.23",
+  "scipy",
   "setuptools",
   "setuptools_scm",
   "wheel",
@@ -22,6 +23,7 @@ classifiers = [
 ]
 dependencies = [
   "numpy<1.23",
+  "scipy",
 ]
 dynamic = ["version"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,6 @@
 requires = [
   "Cython",
   "numpy<1.23",
-  "scipy",
   "setuptools",
   "setuptools_scm",
   "wheel",
@@ -23,7 +22,7 @@ classifiers = [
 ]
 dependencies = [
   "numpy<1.23",
-  "scipy",
+  "scipy<1.12",
 ]
 dynamic = ["version"]
 

--- a/topocalc/horizon.py
+++ b/topocalc/horizon.py
@@ -1,5 +1,6 @@
 import numpy as np
 import numpy.typing as npt
+from scipy.ndimage import median_filter
 
 from topocalc import topo_core
 from topocalc.skew import adjust_spacing, skew
@@ -115,18 +116,19 @@ def horizon(azimuth: float, dem: npt.NDArray, spacing: float) -> npt.NDArray:
         raise ValueError("azimuth not valid")
 
     # Ensure memory is contiguous and type is double for the C extension.
-    elevations = np.require(skewed_dem, dtype=np.double, requirements=['C', 'A'])
+    elevations = np.require(skewed_dem, dtype=np.double, requirements=["C", "A"])
     horizon_cos = np.zeros_like(elevations)
 
     topo_core.c_horizon_2d(
-        elevations,
-        np.double(adjusted_spacing),
-        is_forward,
-        horizon_cos
+        elevations, np.double(adjusted_spacing), is_forward, horizon_cos
     )
 
     if is_skewed:
         horizon_cos = skew(horizon_cos.transpose(), skew_angle, fwd=False)
+        # Subtract striping from the horizon data
+        horizon_cos = horizon_cos - median_filter(
+            horizon_cos - median_filter(horizon_cos, size=(3, 1)), size=(1, 3)
+        )
 
     if transpose_output:
         horizon_cos = horizon_cos.transpose()

--- a/topocalc/horizon.py
+++ b/topocalc/horizon.py
@@ -120,12 +120,19 @@ def horizon(azimuth: float, dem: npt.NDArray, spacing: float) -> npt.NDArray:
     horizon_cos = np.zeros_like(elevations)
 
     topo_core.c_horizon_2d(
-        elevations, np.double(adjusted_spacing), is_forward, horizon_cos
+        elevations,
+        np.double(adjusted_spacing),
+        is_forward,
+        horizon_cos
     )
 
     if is_skewed:
         horizon_cos = skew(horizon_cos.transpose(), skew_angle, fwd=False)
+
         # Subtract striping from the horizon data
+        # Skew is a near perfect transformation, however, the integer snapping caused
+        # by offset will create some striping. Instead of tracking this flipping that occurs 
+        # this solution here uses median_filter to search specifically for linear features.
         horizon_cos = horizon_cos - median_filter(
             horizon_cos - median_filter(horizon_cos, size=(3, 1)), size=(1, 3)
         )

--- a/topocalc/skew.py
+++ b/topocalc/skew.py
@@ -46,7 +46,6 @@ def skew(
         skewed array
 
     """
-
     if angle == 0:
         return arr
 
@@ -74,27 +73,13 @@ def skew(
     if fill_min:
         b += np.min(arr)
 
-    line_indices = np.arange(nlines)
-    o_indices = line_indices if negflag else nlines - line_indices - 1
-    offsets = o_indices * slope
+    for line in range(nlines):
+        o = line if negflag else nlines - line - 1
+        offset = int(o * slope + 0.5)
 
-    output_grid = np.arange(o_nsamps)
-    source_grid = np.arange(nsamps)
-
-    if fwd:
-        for i in range(nlines):
-            offset = offsets[i]
-            source = output_grid - offset
-            mask = (source >= 0) & (source <= nsamps - 1)
-            y_k = np.interp(source[mask], source_grid, arr[i, :])
-            b[i, mask] = y_k
-
-    else:
-        for i in range(nlines):
-            offset = offsets[i]
-            output = source_grid - offset
-            mask = (output >= 0) & (output <= o_nsamps - 1)
-            y_k = np.interp(output_grid, output[mask], arr[i, source_grid[mask]])
-            b[i, :] = y_k
+        if fwd:
+            b[line, offset : offset + nsamps] = arr[line, :]
+        else:
+            b[line, :] = arr[line, offset : offset + o_nsamps]
 
     return b


### PR DESCRIPTION
This looks to address #16 by ensuring interpolation only occurs on the striping artifacts. In this PR the `skew()` method is returned to the same transformation as carried out in the ARS repo.

This update leverages `scipy.ndimage`'s `median_filter` [method](https://docs.scipy.org/doc/scipy/reference/generated/scipy.ndimage.median_filter.html) . To determine if it's a line I use a somewhat arbitrary value of 3pix, passed twice (vertically, horizontally) through median filter.  

```python
horizon_cos = horizon_cos - median_filter(horizon_cos - median_filter(
                             horizon_cos, size=(3, 1)), size=(1, 3))
```

dx=50m
<img width="3762" height="1190" alt="image" src="https://github.com/user-attachments/assets/686f1922-69db-477c-8d01-84c3d8c8dfd4" />

---

Changing the `size` parameter above dramatically impacts the amount filtered by the method. Eyeballing it between the Lakes test and also Kings Canyon Topo file I have locally, this appeared to give the most stable results (size of 3x1 then 1x3). 

This is a nice middle ground, as yes maybe there are still some small striping present, but it's also not interpolating heavily. 

dx=100m
<img width="1259" height="557" alt="Screenshot 2026-03-18 at 18 57 08" src="https://github.com/user-attachments/assets/4a9bc97a-e0eb-4f0d-ac93-d10847a3196e" />
